### PR TITLE
IBM-Swift/Kitura#1042 added getNSError(Error) method

### DIFF
--- a/Sources/Bridging/FoundationAdapterLinux.swift
+++ b/Sources/Bridging/FoundationAdapterLinux.swift
@@ -39,8 +39,8 @@ public class FoundationAdapter: FoundationAdapterProtocol {
         return Bundle(path: (Bundle.main.resourcePath ?? ".") + "/Resources") ?? Bundle.main
     }
 
-    public static func getNSError(from error: Error) -> NSError? {
-        return error as? NSError
+    public static func getNSError(from error: Error?) -> NSError? {
+	return error as? NSError
     }
 }
 #endif

--- a/Sources/Bridging/FoundationAdapterLinux.swift
+++ b/Sources/Bridging/FoundationAdapterLinux.swift
@@ -38,5 +38,9 @@ public class FoundationAdapter: FoundationAdapterProtocol {
         //     inside the resourcePath of Bundle.main (e.g. .build/debug/Resources)
         return Bundle(path: (Bundle.main.resourcePath ?? ".") + "/Resources") ?? Bundle.main
     }
+
+    public static func getNSError(from error: Error) -> NSError? {
+        return error as? NSError
+    }
 }
 #endif

--- a/Sources/Bridging/FoundationAdapterLinux.swift
+++ b/Sources/Bridging/FoundationAdapterLinux.swift
@@ -25,10 +25,18 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     #endif
     public typealias NSMatchingOptions = Foundation.NSMatchingOptions
 
+    /// Return the path component of a URL
+    ///
+    /// - Parameter from: The `URL`
+    /// - Returns: The path component
     public static func getPath(from url: URL) -> String? {
         return url.path
     }
 
+    /// Return the bundle the class belongs to
+    ///
+    /// - Parameter for: The class
+    /// - Returns: The bundle
     public static func getBundle(for aClass: AnyClass) -> Bundle {
         // Bundle(for:) is not yet implemented on Linux
         //TODO remove this ifdef once Bundle(for:) is implemented
@@ -39,6 +47,10 @@ public class FoundationAdapter: FoundationAdapterProtocol {
         return Bundle(path: (Bundle.main.resourcePath ?? ".") + "/Resources") ?? Bundle.main
     }
 
+    /// Converts error to NSError
+    ///
+    /// - Parameter from: The error
+    /// - Returns: The converted `NSError`
     public static func getNSError(from error: Error?) -> NSError? {
 	return error as? NSError
     }

--- a/Sources/Bridging/FoundationAdapterNonLinux.swift
+++ b/Sources/Bridging/FoundationAdapterNonLinux.swift
@@ -21,6 +21,10 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     public typealias RegularExpression = NSRegularExpression
     public typealias NSMatchingOptions = NSRegularExpression.MatchingOptions
 
+    /// Return the path component of a URL
+    ///
+    /// - Parameter from: The `URL`
+    /// - Returns: The path component
     public static func getPath(from url: URL) -> String? {
         if url.path.isEmpty { // in the old foundation, "" means the conversion to path failed
             return nil
@@ -28,10 +32,18 @@ public class FoundationAdapter: FoundationAdapterProtocol {
         return url.path
     }
 
+    /// Return the bundle the class belongs to
+    ///
+    /// - Parameter for: The class
+    /// - Returns: The bundle
     public static func getBundle(for aClass: AnyClass) -> Bundle {
         return Bundle(for: aClass)
     }
 
+    /// Converts error to NSError
+    ///
+    /// - Parameter from: The error
+    /// - Returns: The converted `NSError`
     public static func getNSError(from error: Error?) -> NSError? {
         return error as NSError?
     }

--- a/Sources/Bridging/FoundationAdapterNonLinux.swift
+++ b/Sources/Bridging/FoundationAdapterNonLinux.swift
@@ -32,7 +32,7 @@ public class FoundationAdapter: FoundationAdapterProtocol {
         return Bundle(for: aClass)
     }
 
-    public static func getNSError(from error: Error) -> NSError? {
+    public static func getNSError(from error: Error?) -> NSError? {
         return error as NSError?
     }
 }

--- a/Sources/Bridging/FoundationAdapterNonLinux.swift
+++ b/Sources/Bridging/FoundationAdapterNonLinux.swift
@@ -33,7 +33,7 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     }
 
     public static func getNSError(from error: Error) -> NSError? {
-        return error as NSError
+        return error as NSError?
     }
 }
 #endif

--- a/Sources/Bridging/FoundationAdapterNonLinux.swift
+++ b/Sources/Bridging/FoundationAdapterNonLinux.swift
@@ -31,5 +31,9 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     public static func getBundle(for aClass: AnyClass) -> Bundle {
         return Bundle(for: aClass)
     }
+
+    public static func getNSError(from error: Error) -> NSError? {
+        return error as NSError
+    }
 }
 #endif

--- a/Sources/Bridging/FoundationAdapterProtocol.swift
+++ b/Sources/Bridging/FoundationAdapterProtocol.swift
@@ -25,5 +25,5 @@ import Foundation
 public protocol FoundationAdapterProtocol {
     static func getPath(from: URL) -> String?
     static func getBundle(for aClass: AnyClass) -> Bundle
-    static func getNSError(from: Error) -> NSError?
+    static func getNSError(from: Error?) -> NSError?
 }

--- a/Sources/Bridging/FoundationAdapterProtocol.swift
+++ b/Sources/Bridging/FoundationAdapterProtocol.swift
@@ -23,7 +23,21 @@ import Foundation
 // it is not itended to contain an exhaustive list of discrepancies
 
 public protocol FoundationAdapterProtocol {
+    /// Return the path component of a URL
+    ///
+    /// - Parameter from: The `URL`
+    /// - Returns: The path component
     static func getPath(from: URL) -> String?
+
+    /// Return the bundle the class belongs to
+    ///
+    /// - Parameter for: The class
+    /// - Returns: The bundle
     static func getBundle(for aClass: AnyClass) -> Bundle
+
+    /// Converts error to NSError
+    ///
+    /// - Parameter from: The error
+    /// - Returns: The converted `NSError`
     static func getNSError(from: Error?) -> NSError?
 }

--- a/Sources/Bridging/FoundationAdapterProtocol.swift
+++ b/Sources/Bridging/FoundationAdapterProtocol.swift
@@ -25,4 +25,5 @@ import Foundation
 public protocol FoundationAdapterProtocol {
     static func getPath(from: URL) -> String?
     static func getBundle(for aClass: AnyClass) -> Bundle
+    static func getNSError(from: Error) -> NSError?
 }


### PR DESCRIPTION
since there is bridging from Error on NSError on Mac and there is no
bridging on Linux

@na-gupta please merge.