### PR TITLE
Remove `return error as? NSError` on Linux to prevent runtime crash -- IBM-Swift/Kitura#1043

### DIFF
--- a/Sources/Bridging/FoundationAdapterLinux.swift
+++ b/Sources/Bridging/FoundationAdapterLinux.swift
@@ -52,7 +52,10 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     /// - Parameter from: The error
     /// - Returns: The converted `NSError`
     public static func getNSError(from error: Error?) -> NSError? {
-	return error as? NSError
+        if let error = error {
+            return NSError(domain: error.localizedDescription, code: -1)
+        }
+        return nil
     }
 }
 #endif

--- a/Sources/Bridging/FoundationAdapterNonLinux.swift
+++ b/Sources/Bridging/FoundationAdapterNonLinux.swift
@@ -45,7 +45,10 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     /// - Parameter from: The error
     /// - Returns: The converted `NSError`
     public static func getNSError(from error: Error?) -> NSError? {
-        return error as NSError?
+        if let error = error {
+            return NSError(domain: error.localizedDescription, code: -1)
+        }
+        return nil
     }
 }
 #endif

--- a/Sources/Bridging/FoundationAdapterNonLinux.swift
+++ b/Sources/Bridging/FoundationAdapterNonLinux.swift
@@ -45,10 +45,7 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     /// - Parameter from: The error
     /// - Returns: The converted `NSError`
     public static func getNSError(from error: Error?) -> NSError? {
-        if let error = error {
-            return NSError(domain: error.localizedDescription, code: -1)
-        }
-        return nil
+        return error as NSError?
     }
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In `FoundationAdapterLinux.swift`, `return error as? NSError` will always return nil because Error and NSError are currently not bridged on Linux. So changed to `NSError(domain: error.localizedDescription, code: -1)`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IBM-Swift/Kitura#1043
https://bugs.swift.org/browse/SR-3872
"bridging Error to NSError is NOT ALLOWED on Linux"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
