### PR TITLE
Swift 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,18 @@ matrix:
       dist: trusty
       sudo: required
       env: SWIFT_VERSION=3.0.2
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_VERSION=4.0
     - os: osx
       osx_image: xcode8.3
       sudo: required
+      env: SWIFT_VERSION=3.1
+    - os: osx
+      osx_image: xcode9
+      sudo: required
+      env: SWIFT_VERSION=4.0
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:4.0
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import PackageDescription
+
+let package = Package(
+    name: "Bridging",
+    products: [
+        .library(name: "Bridging", targets: ["Bridging"])
+    ],
+    targets: [
+        .target(name: "Bridging")
+    ]
+)

--- a/Sources/Bridging/FoundationAdapterLinux.swift
+++ b/Sources/Bridging/FoundationAdapterLinux.swift
@@ -23,7 +23,11 @@ public class FoundationAdapter: FoundationAdapterProtocol {
     #else
         public typealias RegularExpression = Foundation.RegularExpression
     #endif
-    public typealias NSMatchingOptions = Foundation.NSMatchingOptions
+    #if swift(>=3.2)
+        public typealias NSMatchingOptions = NSRegularExpression.MatchingOptions
+    #else
+        public typealias NSMatchingOptions = Foundation.NSMatchingOptions
+    #endif
 
     /// Return the path component of a URL
     ///


### PR DESCRIPTION
Minor update for Swift 4 required due to renaming of Foundation's `NSMatchingOptions` to `NSRegularExpression.MatchingOptions`:  https://github.com/apple/swift-corelibs-foundation/pull/1165

Adds:
- a clause for the new naming depending on which Swift version is being used
- Package@swift-4.0.swift to match the other repos that remain compatible with both Swift 4 and 3.1
- Travis build with Swift 4 